### PR TITLE
patch: removed use-dockerhub

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,6 +3,6 @@
 # Why is it required?
 
 # PR checklist
-- [ ] Run tests locally
-- [ ] Updated Readme
-- [ ] Updated Changelog
+- [ ] Run container-security-action-demo against this branch
+- [ ] Updated Readme (where required)
+- [ ] Updated Changelog (where required)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,16 @@
 
 [//]: # (### Deprecated/Removed:)
 
-## [ 2024/01/23 - v0.0.2 ]
+## [ 2024/01/27 - v0.0.2 ]
 
 ### Added/Changed:
 
 * Changed aws- prefixed to s3-prefixed to remove any confusion around aws requirement
 * Updated action versions
+* Added step to determine the repo type based on the repo name. If there is no period, it's presumed a DockerHub registry
+
+### Removed
+* removed `use-dockerhub` as it's determined based on the repo-name.
 
 ## [ 2024/01/23 - v0.0.1 ]
 

--- a/README.md
+++ b/README.md
@@ -75,38 +75,39 @@ files.
 ## Signing images with Cosign
 
 The Cosign image signing works by using the standard process used by Cosign.
-You will need to generate the [Cosign keys as described in their documentation](https://docs.sigstore.dev/key_management/overview/) and store these as a secret in GitHub.
+You will need to generate
+the [Cosign keys as described in their documentation](https://docs.sigstore.dev/key_management/overview/) and store
+these as a secret in GitHub.
 This can then be supplied via the `cosign-private-key` and `cosign-password` inputs.
 
 **Hardware token verification is currently not supported.**
 
 ## Inputs
 
-| Name                   | Description                                        | Required | Default                        |
-|------------------------|----------------------------------------------------|----------|--------------------------------|
-| use-dockerhub          | Set to true to use dockerhub.                      | false    | false                          |
-| image-repo             | The repo to push the image to.                     | true     | -                              |
-| repo-username          | The username to log into the repo.                 | true     | -                              |
-| repo-password          | The password to log into the repo.                 | true     | -                              |
-| image-name             | The name of the image to build.                    | true     | -                              |
-| image-tag              | The tag to build the image with.                   | true     | -                              |
-| add-latest-tag         | Adds a latest tag to the image                     | true     | false                          |
-| cosign-private-key     | A private key to sign the image using Cosign.      | true     | -                              |
-| cosign-password        | The password to unlock the private key.            | true     | -                              |
-| cosign-tlog            | Set to true to upload to tlog for transparency.    | false    | 'false'                        |
-| publish-image          | If true, the image will be published to the repo.  | false    | 'false'                        |
-| check-severity         | Comma-delimited list of severities to check for.   | false    | high                           |
-| sbom-fail-on-detection | Exit code for Trivy SBOM scan.                     | false    | "1"                            |
-| scan-fail-on-detection | Exit code for Trivy scan.                          | false    | "2"                            |
-| trivyignore-file       | Trivy ignore file to prevent pipeline failure.     | false    | "trivyignore"                  |
-| trivyignore-from-s3    | Supply trivyignore via S3.                         | false    | false                          |
-| s3-endpoint            | Custom AWS S3 endpoint if not standard.            | false    | "https://some-s3-endpoint.com" |
-| s3-region              | The AWS Region.                                    | false    | "us-east-1"                    |
-| s3-access-key          | The S3 access key.                                 | false    | ""                             |
-| s3-secret-key          | The S3 secret key.                                 | false    | ""                             |
-| s3-bucket              | The S3 bucket for trivyignore file.                | false    | "trivy"                        |
-| s3-path                | The path in the S3 bucket to the trivyignore file. | false    | "trivyignore"                  |
-| dockerfile-path        | Path to the Dockerfile.                            | false    | "."                            |
+| Name                   | Description                                                                                                                                                                                              | Required | Default                        |
+|------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|--------------------------------|
+| image-repo             | The repo to push the image to. This should just be the base url, eg: my-repo or ghcr.io or, if using DockerHub, just the username you'd usually use for your repo (you must also specify use-dockerhub). | true     | -                              |
+| repo-username          | The username to log into the repo.                                                                                                                                                                       | true     | -                              |
+| repo-password          | The password to log into the repo.                                                                                                                                                                       | true     | -                              |
+| image-name             | The name of the image to build.                                                                                                                                                                          | true     | -                              |
+| image-tag              | The tag to build the image with.                                                                                                                                                                         | true     | -                              |
+| add-latest-tag         | Adds a latest tag to the image                                                                                                                                                                           | true     | false                          |
+| cosign-private-key     | A private key to sign the image using Cosign.                                                                                                                                                            | true     | -                              |
+| cosign-password        | The password to unlock the private key.                                                                                                                                                                  | true     | -                              |
+| cosign-tlog            | Set to true to upload to tlog for transparency.                                                                                                                                                          | false    | 'false'                        |
+| publish-image          | If true, the image will be published to the repo.                                                                                                                                                        | false    | 'false'                        |
+| check-severity         | Comma-delimited list of severities to check for.                                                                                                                                                         | false    | high                           |
+| sbom-fail-on-detection | Exit code for Trivy SBOM scan.                                                                                                                                                                           | false    | "1"                            |
+| scan-fail-on-detection | Exit code for Trivy scan.                                                                                                                                                                                | false    | "2"                            |
+| trivyignore-file       | Trivy ignore file to prevent pipeline failure.                                                                                                                                                           | false    | "trivyignore"                  |
+| trivyignore-from-s3    | Supply trivyignore via S3.                                                                                                                                                                               | false    | false                          |
+| s3-endpoint            | Custom AWS S3 endpoint if not standard.                                                                                                                                                                  | false    | "https://some-s3-endpoint.com" |
+| s3-region              | The AWS Region.                                                                                                                                                                                          | false    | "us-east-1"                    |
+| s3-access-key          | The S3 access key.                                                                                                                                                                                       | false    | ""                             |
+| s3-secret-key          | The S3 secret key.                                                                                                                                                                                       | false    | ""                             |
+| s3-bucket              | The S3 bucket for trivyignore file.                                                                                                                                                                      | false    | "trivy"                        |
+| s3-path                | The path in the S3 bucket to the trivyignore file.                                                                                                                                                       | false    | "trivyignore"                  |
+| dockerfile-path        | Path to the Dockerfile.                                                                                                                                                                                  | false    | "."                            |
 
 ## TODO (AKA nice to haves but may not come!):
 

--- a/action.yml
+++ b/action.yml
@@ -6,12 +6,10 @@ branding:
   icon: layers
   color: purple
 inputs:
-  use-dockerhub:
-    description: "Set to true to use dockerhub."
-    required: false
   image-repo:
-    description: "The repo to push the image to."
+    description: "The repo to push the image to. This should just be the base url, eg: my-repo or ghcr.io or, if using DockerHub, just the username you'd usually use for your repo."
     required: true
+
   repo-username:
     description: "The username to log into the repo."
     required: true
@@ -61,7 +59,7 @@ inputs:
   trivyignore-from-s3:
     description: "If disabled, the trivyignore can be supplied via the repo itself but actions/checkout@v4 must be used before calling this action."
     required: false
-    default: false
+    default: "false"
   s3-endpoint:
     description: "If the endpoint isn't a standard AWS one, pass it in here."
     required: false
@@ -189,35 +187,41 @@ runs:
       if: inputs.publish-image == 'true'
       uses: sigstore/cosign-installer@v3.3.0
 
-    ### USING DOCKERHUB ###
+    - name: Determine Registry
+      if: inputs.publish-image == 'true'
+      shell: bash
+      run: |
+        IS_DOCKERHUB="true"
+        REPO="${{ inputs.image-repo }}"
+        
+        if echo "${{ inputs.image-repo }}" | grep -E -q '\.'; then
+          IS_DOCKERHUB="false"
+        fi
+        
+        if [ "${{ inputs.image-repo }}" == "ghcr.io" ]; then
+          REPO="${{ inputs.image-repo }}/${{ inputs.repo-username }}"
+        fi
+        
+        echo "IS_DOCKERHUB=${IS_DOCKERHUB}" >> "$GITHUB_ENV"
+        echo "REPO=${REPO}" >> "$GITHUB_ENV"
+
     # Login into registry
-    - name: Login to GitHub Container Registry
-      if: inputs.publish-image == 'true' && inputs.use-dockerhub == 'true'
+    ### USING DOCKERHUB ###
+    - name: Login to Docker Registry
+      if: inputs.publish-image == 'true' && env.IS_DOCKERHUB == 'true'
       uses: docker/login-action@v3
       with:
         username: ${{ inputs.repo-username }}
         password: ${{ inputs.repo-password }}
 
-    ### USING ALT REPO ###
-    # Login into registry
-    - name: Login to GitHub Container Registry
-      if: inputs.publish-image == 'true' && inputs.use-dockerhub != 'true'
+    ### USING NON-DOCKERHUB ###
+    - name: Login to Container Registry
+      if: inputs.publish-image == 'true' && env.IS_DOCKERHUB == 'false'
       uses: docker/login-action@v3
       with:
         registry: ${{ inputs.image-repo }}
         username: ${{ inputs.repo-username }}
         password: ${{ inputs.repo-password }}
-
-    - name: Get Repo
-      shell: bash
-      if: inputs.publish-image == 'true'
-      run: |
-        export REPO=${{ inputs.image-repo }}/${{ inputs.repo-username }}
-        if [ ${{inputs.use-dockerhub}} ]; then
-          echo "REPO=${{ inputs.image-repo }}" >> "$GITHUB_ENV"
-        else
-          echo "REPO=${{ inputs.image-repo }}/${{ inputs.repo-username }}" >> "$GITHUB_ENV"
-        fi
 
     # Push the image with the user-defined tag
     - name: Build and push


### PR DESCRIPTION
# What's Changed
Added a step for determining the registry typeso that `use-dockerhub` is no longer needed to be explicitly defined

# Why is it required?
UX

# PR checklist
- [x] Run tests locally
- [x] Updated Readme
- [x] Updated Changelog
